### PR TITLE
typo in docs/make.jl

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,5 +15,5 @@ makedocs(
 )
 
 deploydocs(
-    repo = "github.com/juliaastro/skycoords.jl.git"
+    repo = "github.com/JuliaAstro/SkyCoords.jl.git"
 )


### PR DESCRIPTION
FIx typo for deployment.

In addition, the documenter keys need to be set in Travis and from this repo.