### PR TITLE
support ConstructionBase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,11 @@ version = "1.0.0"
 
 [deps]
 AstroAngles = "5c4adb95-c1fc-4c53-b4ea-2a94080c53d2"
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 AstroAngles = "0.1"
+ConstructionBase = "1"
 StaticArrays = "0.8, 0.9, 1"
 julia = "1.3"

--- a/src/SkyCoords.jl
+++ b/src/SkyCoords.jl
@@ -2,6 +2,7 @@ __precompile__()
 
 module SkyCoords
 using StaticArrays
+import ConstructionBase: constructorof
 
 export AbstractSkyCoords, 
        ICRSCoords,

--- a/src/types.jl
+++ b/src/types.jl
@@ -69,6 +69,7 @@ FK5Coords{e}(ra::Real, dec::Real) where {e} =
     FK5Coords{e}(promote(float(ra), float(dec))...)
 FK5Coords{e}(c::T) where {e,T<:AbstractSkyCoords} = convert(FK5Coords{e}, c)
 FK5Coords{e,F}(c::T) where {e,F,T<:AbstractSkyCoords} = convert(FK5Coords{e,F}, c)
+constructorof(::Type{<:FK5Coords{e}}) where {e} = FK5Coords{e}
 
 
 # Scalar coordinate conversions

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 AstroAngles = "5c4adb95-c1fc-4c53-b4ea-2a94080c53d2"
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using Printf
 using SkyCoords
 using Statistics
 using Test
+using ConstructionBase: setproperties
 
 import SkyCoords: lat, lon
 
@@ -178,4 +179,10 @@ end
     c2 = offset(c1, deg2rad(1), deg2rad(90))
     @test 11.9 < lon(c2) |> rad2deg < 12.0
     @test 59.9 < lat(c2) |> rad2deg < 60.0
+end
+
+@testset "constructionbase" begin
+    @test setproperties(ICRSCoords(1, 2), ra=3) == ICRSCoords(3, 2)
+    @test setproperties(GalCoords(1, 2), l=3) == GalCoords(3, 2)
+    @test setproperties(FK5Coords{2000}(1, 2), ra=3) == FK5Coords{2000}(3, 2)
 end


### PR DESCRIPTION
manual implementation only needed for `FK5Coords{e}` due to the type parameter, other types work out of the box
allows interop with packages listed at https://github.com/JuliaObjects/ConstructionBase.jl
