### PR TITLE
Support Accessors.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SkyCoords"
 uuid = "fc659fc5-75a3-5475-a2ea-3da92c065361"
 authors = "Kyle Barbary, Mosé Giordano, and contributors"
-version = "1.2.1"
+version = "1.3.0"
 
 [deps]
 AstroAngles = "5c4adb95-c1fc-4c53-b4ea-2a94080c53d2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SkyCoords"
 uuid = "fc659fc5-75a3-5475-a2ea-3da92c065361"
 authors = "Kyle Barbary, Mosé Giordano, and contributors"
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 AstroAngles = "5c4adb95-c1fc-4c53-b4ea-2a94080c53d2"
@@ -10,9 +10,19 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
+[weakdeps]
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+
+[extensions]
+AccessorsExt = "Accessors"
+
 [compat]
+Accessors = "0.1"
 AstroAngles = "0.1"
 ConstructionBase = "1"
 Rotations = "1"
 StaticArrays = "0.8, 0.9, 1"
 julia = "1.6"
+
+[extras]
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/ext/AccessorsExt.jl
+++ b/ext/AccessorsExt.jl
@@ -1,0 +1,23 @@
+module AccessorsExt
+using Accessors
+import Accessors: set
+using SkyCoords
+using SkyCoords: lat, lon
+
+set(x::GalCoords, ::typeof(lon), v) = @set x.l = v
+set(x::GalCoords, ::typeof(lat), v) = @set x.b = v
+set(x::EclipticCoords, ::typeof(lon), v) = @set x.lon = v
+set(x::EclipticCoords, ::typeof(lat), v) = @set x.lat = v
+set(x::ICRSCoords, ::typeof(lon), v) = @set x.ra = v
+set(x::ICRSCoords, ::typeof(lat), v) = @set x.dec = v
+set(x::FK5Coords, ::typeof(lon), v) = @set x.ra = v
+set(x::FK5Coords, ::typeof(lat), v) = @set x.dec = v
+
+set(x::CartesianCoords, ::typeof(vec), v) = @set x.vec = v
+
+set(x::CartesianCoords, ::typeof(cartesian), v::CartesianCoords) = cartesian(v)
+set(x::CartesianCoords, ::typeof(spherical), v::AbstractSkyCoords) = cartesian(v)
+set(x::AbstractSkyCoords, ::typeof(cartesian), v::CartesianCoords) = spherical(v)
+set(x::AbstractSkyCoords, ::typeof(spherical), v::AbstractSkyCoords) = spherical(v)
+
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -89,7 +89,7 @@ struct EclipticCoords{e,T<:AbstractFloat} <: AbstractSkyCoords
     EclipticCoords{e,T}(lon, lat) where {e,T<:AbstractFloat} = new(mod2pi(lon), lat)
 end
 EclipticCoords{e}(lon::T, lat::T) where {e,T<:AbstractFloat} = EclipticCoords{e,T}(lon, lat)
-EclipticCoords{e}(lon::Real, lat::Real) where {e} = EclipticCoords(promote(float(lon), float(lat))...)
+EclipticCoords{e}(lon::Real, lat::Real) where {e} = EclipticCoords{e}(promote(float(lon), float(lat))...)
 EclipticCoords{e}(c::AbstractSkyCoords) where {e} = convert(EclipticCoords{e}, c)
 EclipticCoords{e,F}(c::AbstractSkyCoords) where {e,F} = convert(EclipticCoords{e,F}, c)
 constructorof(::Type{<:EclipticCoords{e}}) where {e} = EclipticCoords{e}

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 AstroAngles = "5c4adb95-c1fc-4c53-b4ea-2a94080c53d2"
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using AstroAngles
+using Accessors
 using ConstructionBase: setproperties
 using DelimitedFiles
 using LinearAlgebra: normalize
@@ -164,6 +165,28 @@ end
     @test setproperties(FK5Coords{2000}(1, 2), ra=3) == FK5Coords{2000}(3, 2)
     @test setproperties(EclipticCoords{2000}(1, 2), lon=3) == EclipticCoords{2000}(3, 2)
     @test setproperties(cartesian(ICRSCoords(1, 2)), vec=[1., 0, 0]) == cartesian(ICRSCoords(0, 0))
+end
+
+VERSION > v"1.9-DEV" && @testset "Accessors" begin
+    @testset for c in (ICRSCoords(1, 0.5), FK5Coords{2000}(1, 0.5), GalCoords(1, 0.5), EclipticCoords{2000}(1, 0.5))
+        Accessors.test_getset_laws(lon, c, 1.5, 0.123)
+        Accessors.test_getset_laws(lat, c, 1.5, 0.123)
+
+        cart = cartesian(c)
+        cart1 = @set lat(spherical(cart)) = 0.123
+        @test typeof(cart1) == typeof(cart)
+        @test lat(spherical(cart1)) ≈ 0.123
+
+        c1 = @set vec(cartesian(c)) = [1., 0, 0]
+        @test typeof(c1) == typeof(c)
+        @test lat(c1) == 0
+        @test lon(c1) == 0
+
+        Accessors.test_getset_laws(spherical, c, c1, c; cmp = ≈)
+        Accessors.test_getset_laws(cartesian, c, cart1, cart; cmp = ≈)
+        Accessors.test_getset_laws(spherical, cart, c1, c; cmp = ≈)
+        Accessors.test_getset_laws(cartesian, cart, cart1, cart; cmp = ≈)
+    end
 end
 
 @testset "equality" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,7 @@ include("astropy.jl")
     c5 = ICRSCoords(ℯ, 1 + pi / 2)
     @test separation(c1, c5) ≈ separation(c5, c1) ≈ separation(c1, convert(GalCoords, c5)) ≈
           separation(convert(FK5Coords{1980}, c5), c1) ≈ 1
-    for T in (GalCoords, FK5Coords{2000})
+    for T in (GalCoords, FK5Coords{2000}, EclipticCoords{2000})
         c2 = convert(T{Float32}, c1)
         c3 = convert(T{Float64}, c1)
         c4 = convert(T{BigFloat}, c1)
@@ -40,6 +40,8 @@ end
     GalCoords,
     FK5Coords{2000},
     FK5Coords{1970},
+    EclipticCoords{2000},
+    EclipticCoords{1970},
 ]
     @test C(hms"0h0m0", dms"0d0m0") == C(0.0, 0.0)
     @test C(hms"12h0.0m0.0s", dms"90:0:0") == C(π, π / 2)
@@ -66,7 +68,7 @@ end
     @test position_angle(c1, c4) ≈ 0
 
     # types
-    for T in [ICRSCoords, GalCoords, FK5Coords{2000}]
+    for T in [ICRSCoords, GalCoords, FK5Coords{2000}, EclipticCoords{2000}]
         c1 = T(0, 0)
         c2 = T(deg2rad(1), 0)
         @test position_angle(c1, c2) ≈ π / 2
@@ -75,7 +77,7 @@ end
 
 
 
-@testset "Offset ($T1, $T2)" for T1 in [ICRSCoords, GalCoords, FK5Coords{2000}], T2 in [ICRSCoords, GalCoords, FK5Coords{2000}]
+@testset "Offset ($T1, $T2)" for T1 in [ICRSCoords, GalCoords, FK5Coords{2000}, EclipticCoords{2000}], T2 in [ICRSCoords, GalCoords, FK5Coords{2000}, EclipticCoords{2000}]
     # simple integration tests, depend that separation and position_angle are accurate
     c1s = [
         T1(0, -π/2), # south pole
@@ -125,7 +127,7 @@ end
 end
 
 @testset "cartesian" begin
-    for CT in [ICRSCoords, FK5Coords{2000}, FK5Coords{1975}, GalCoords]
+    for CT in [ICRSCoords, FK5Coords{2000}, FK5Coords{1975}, EclipticCoords{2000}, EclipticCoords{1975}, GalCoords]
         @test cartesian(CT(0, 0)) |> vec ≈ [1, 0, 0]
         @test cartesian(CT(0, π/2)) |> vec ≈ [0, 0, 1]
         @test cartesian(CT(π/2, 0)) |> vec ≈ [0, 1, 0]
@@ -160,11 +162,12 @@ end
     @test setproperties(ICRSCoords(1, 2), ra=3) == ICRSCoords(3, 2)
     @test setproperties(GalCoords(1, 2), l=3) == GalCoords(3, 2)
     @test setproperties(FK5Coords{2000}(1, 2), ra=3) == FK5Coords{2000}(3, 2)
+    @test setproperties(EclipticCoords{2000}(1, 2), lon=3) == EclipticCoords{2000}(3, 2)
     @test setproperties(cartesian(ICRSCoords(1, 2)), vec=[1., 0, 0]) == cartesian(ICRSCoords(0, 0))
 end
 
 @testset "equality" begin
-    @testset for T in [ICRSCoords, GalCoords, FK5Coords{2000}]
+    @testset for T in [ICRSCoords, GalCoords, FK5Coords{2000}, EclipticCoords{2000}]
         c1 = T(1., 2.)
         c2 = T(1., 2.001)
         c3 = T{Float32}(1., 2.)
@@ -184,7 +187,7 @@ end
 end
 
 @testset "conversion" begin
-    systems = (ICRSCoords, FK5Coords{2000}, FK5Coords{1975}, GalCoords)
+    systems = (ICRSCoords, FK5Coords{2000}, FK5Coords{1975}, EclipticCoords{2000}, EclipticCoords{1975}, GalCoords)
     for IN_SYS in systems, OUT_SYS in systems
         coord_in = IN_SYS(rand(rng), rand(rng))
         coord_out = convert(OUT_SYS, coord_in)


### PR DESCRIPTION
Useful for code that works with coordinates generically and needs to modify them.

Also: fix unnoticed bug in EclipticCoords, add them to all tests.

Accessors only for 1.9, nothing is changed on older julia versions. Accessors.jl contains integrations with stable widely-used packages itself (eg https://github.com/JuliaObjects/Accessors.jl/pull/87), but it makes more sense to keep SkyCoords intergration here.