### PR TITLE
Tighten AstroAngles compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ UnitfulExt = "Unitful"
 
 [compat]
 Accessors = "0.1"
-AstroAngles = "0.1"
+AstroAngles = "0.2"
 ConstructionBase = "1"
 Rotations = "1"
 StaticArrays = "0.8, 0.9, 1"


### PR DESCRIPTION
AstroAngles 0.1 uses Formatting.jl, which should be avoided. Fixed in AstroAngles 0.2