### PR TITLE
Remove macOS 13 from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-          - macos-13 # TODO: Remove this line when `macos-13` won't be available anymore
           - macos-latest
           - windows-latest
         exclude:


### PR DESCRIPTION
Removed deprecated macOS version from CI workflow (see failures on the CI runs for #81).