### PR TITLE
docs: Create docstrings for `cartesian` and `spherical` functions

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -19,6 +19,7 @@ GalCoords
 SuperGalCoords
 FK5Coords
 EclipticCoords
+CartesianCoords
 ```
 
 ## Conversion
@@ -62,4 +63,6 @@ inrange
 separation
 position_angle
 offset
+cartesian
+spherical
 ```

--- a/src/cartesian.jl
+++ b/src/cartesian.jl
@@ -28,8 +28,7 @@ coords2cart(c::CartesianCoords) = vec(c)
 """
     cartesian(c::AbstractSkyCoords)
 
-Returns an instance of `CartesianCoords`, where a 2-dimensional angle in the sky
-is projected onto the unit sphere in Cartesian (rectangular) coordinates.
+Returns a Cartesian representation of the coordinate `c` projected onto the unit sphere as a [`CartesianCoords`](@ref).
 
 ### See also
 [`spherical`](@ref)

--- a/src/cartesian.jl
+++ b/src/cartesian.jl
@@ -29,9 +29,10 @@ coords2cart(c::CartesianCoords) = vec(c)
     cartesian(c::AbstractSkyCoords)
 
 Returns an instance of `CartesianCoords`, where a 2-dimensional angle in the sky
-is projected onto the unit sphere.
+is projected onto the unit sphere in Cartesian (rectangular) coordinates.
 
-See also: [`spherical`](@ref)
+### See also
+[`spherical`](@ref)
 """
 cartesian(c::CartesianCoords) = c
 cartesian(c::T) where {T <: AbstractSkyCoords} = CartesianCoords{T}(coords2cart(lon(c), lat(c)))
@@ -39,10 +40,13 @@ cartesian(c::T) where {T <: AbstractSkyCoords} = CartesianCoords{T}(coords2cart(
 """
     spherical(c::AbstractSkyCoords)
 
-Returns the spherical representation of a coordinate set as two angles:
-the co-latitude and the azimuth.
+Returns the spherical representation of a coordinate set. In general, all
+subtypes of [`AbstractSkyCoords`](@ref) store the coordinates as two angles, so
+an instance of the same type is returned. If `c` is a [`CartesianCoords`](@ref)
+object, the coordinates are unwrapped and the underlying coordinate is returned.
 
-See also: [`cartesian`](@ref)
+### See also
+[`cartesian`](@ref)
 """
 spherical(c::AbstractSkyCoords) = c
 spherical(c::CartesianCoords{T}) where {T <: AbstractSkyCoords} = T(cart2coords(vec(c))...)

--- a/src/cartesian.jl
+++ b/src/cartesian.jl
@@ -12,9 +12,27 @@ constructorof(::Type{<:CartesianCoords{TC}}) where {TC} = CartesianCoords{TC}
 Base.vec(c::CartesianCoords) = c.vec
 
 coords2cart(c::CartesianCoords) = vec(c)
+
+"""
+    cartesian(c::AbstractSkyCoords)
+
+Returns an instance of `CartesianCoords`, where a 2-dimensional angle in the sky
+is projected onto the unit sphere.
+
+See also: [`spherical`](@ref)
+"""
 cartesian(c::CartesianCoords) = c
-spherical(c::AbstractSkyCoords) = c
 cartesian(c::T) where {T <: AbstractSkyCoords} = CartesianCoords{T}(coords2cart(lon(c), lat(c)))
+
+"""
+    spherical(c::AbstractSkyCoords)
+
+Returns the spherical representation of a coordinate set as two angles:
+the co-latitude and the azimuth.
+
+See also: [`cartesian`](@ref)
+"""
+spherical(c::AbstractSkyCoords) = c
 spherical(c::CartesianCoords{T}) where {T <: AbstractSkyCoords} = T(cart2coords(vec(c))...)
 
 Base.convert(::Type{<:T}, c::CartesianCoords{S}) where {T <: AbstractSkyCoords, S <: AbstractSkyCoords} =

--- a/src/cartesian.jl
+++ b/src/cartesian.jl
@@ -39,10 +39,7 @@ cartesian(c::T) where {T <: AbstractSkyCoords} = CartesianCoords{T}(coords2cart(
 """
     spherical(c::AbstractSkyCoords)
 
-Returns the spherical representation of a coordinate set. In general, all
-subtypes of [`AbstractSkyCoords`](@ref) store the coordinates as two angles, so
-an instance of the same type is returned. If `c` is a [`CartesianCoords`](@ref)
-object, the coordinates are unwrapped and the underlying coordinate is returned.
+Returns the spherical representation of the coordinate `c`. Coordinate arguments that are already in spherical coordinates are simply returned. If `c` is a [`CartesianCoords`](@ref) object, the Cartesian representation is converted to spherical and returned as a `T <: AbstractSkyCoords` where `c::CartesianCoords{T}`. 
 
 ### See also
 [`cartesian`](@ref)

--- a/src/cartesian.jl
+++ b/src/cartesian.jl
@@ -1,3 +1,15 @@
+"""
+    CartesianCoords{TC <: AbstractSkyCoords, TF} <: AbstractSkyCoords
+    CartesianCoords{TC}(x, y, z)
+    CartesianCoords(c::AbstractSkyCoords)
+
+Cartesian representation of arbitrary coordinate systems.
+The type paramter `TC` identifies the coordinate scheme being encoded.
+Instances of this type should be created using the [`cartesian`](@ref) function.
+
+Note: since all sky coordinates are angle measures, the Cartesian coordinates
+are assumed to lie on the unit sphere.
+"""
 struct CartesianCoords{TC <: AbstractSkyCoords, TF <: Real} <: AbstractSkyCoords
     vec::SVector{3, TF}
 end


### PR DESCRIPTION
Closes #84