### PR TITLE
fix!: Catch angles outside of domain

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SkyCoords"
 uuid = "fc659fc5-75a3-5475-a2ea-3da92c065361"
-version = "1.7.1"
+version = "2.0.0"
 authors = "Kyle Barbary, Mosé Giordano, and contributors"
 
 [deps]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -65,4 +65,5 @@ position_angle
 offset
 cartesian
 spherical
+SkyCoords.checklat
 ```

--- a/src/types.jl
+++ b/src/types.jl
@@ -9,6 +9,24 @@ The supertype for all sky coordinate systems.
 abstract type AbstractSkyCoords end
 
 """
+    checklat(lat)
+
+Validate that a latitude-like coordinate (declination, galactic latitude, etc.),
+given in radians, lies within the physical range `[-π/2, π/2]`.
+Throws an `ArgumentError` otherwise, and returns `lat` unchanged when valid.
+
+Every concrete `AbstractSkyCoords` subtype calls this from its inner constructor.
+Unlike longitude, which is periodic and safe to wrap with `mod2pi`, an out-of-range latitude
+does not have an unambiguous "wrapped" meaning without also flipping the longitude by π,
+so it is rejected instead.
+"""
+function checklat(lat)
+    -π / 2 <= lat <= π / 2 ||
+        throw(ArgumentError("Latitude/declination must be in [-π/2, π/2] radians, got $(lat)."))
+    return lat
+end
+
+"""
     ICRSCoords <: AbstractSkyCoords
     ICRSCoords(ra, dec)
 
@@ -23,7 +41,7 @@ This is the current standard adopted by the International Astronomical Union not
 struct ICRSCoords{T <: Real} <: AbstractSkyCoords
     ra::T
     dec::T
-    ICRSCoords{T}(ra, dec) where {T <: Real} = new(mod2pi(ra), dec)
+    ICRSCoords{T}(ra, dec) where {T <: Real} = new(mod2pi(ra), checklat(dec))
 end
 ICRSCoords(ra::T, dec::T) where {T <: Real} = ICRSCoords{float(T)}(ra, dec)
 ICRSCoords(ra::Real, dec::Real) = ICRSCoords(promote(ra, dec)...)
@@ -45,7 +63,7 @@ This coordinate system is defined based on the projection of the Milky Way galax
 struct GalCoords{T <: Real} <: AbstractSkyCoords
     l::T
     b::T
-    GalCoords{T}(l, b) where {T <: Real} = new(mod2pi(l), b)
+    GalCoords{T}(l, b) where {T <: Real} = new(mod2pi(l), checklat(b))
 end
 GalCoords(l::T, b::T) where {T <: Real} = GalCoords{float(T)}(l, b)
 GalCoords(l::Real, b::Real) = GalCoords(promote(l, b)...)
@@ -67,7 +85,7 @@ The supergalactic plane as so-far observed is more or less perpendicular to the 
 struct SuperGalCoords{T <: Real} <: AbstractSkyCoords
     l::T
     b::T
-    SuperGalCoords{T}(l, b) where {T <: Real} = new(mod2pi(l), b)
+    SuperGalCoords{T}(l, b) where {T <: Real} = new(mod2pi(l), checklat(b))
 end
 SuperGalCoords(l::T, b::T) where {T <: Real} = SuperGalCoords{float(T)}(l, b)
 SuperGalCoords(l::Real, b::Real) = SuperGalCoords(promote(l, b)...)
@@ -95,7 +113,7 @@ frame.
 struct FK5Coords{e, T <: Real} <: AbstractSkyCoords
     ra::T
     dec::T
-    FK5Coords{e, T}(ra, dec) where {T <: Real, e} = new(mod2pi(ra), dec)
+    FK5Coords{e, T}(ra, dec) where {T <: Real, e} = new(mod2pi(ra), checklat(dec))
 end
 FK5Coords{e}(ra::T, dec::T) where {e, T <: Real} = FK5Coords{e, float(T)}(ra, dec)
 FK5Coords{e}(ra::Real, dec::Real) where {e} = FK5Coords{e}(promote(ra, dec)...)
@@ -118,7 +136,7 @@ This coordinate system is geocentric with the ecliptic plane as the xy-plane wit
 struct EclipticCoords{e, T <: Real} <: AbstractSkyCoords
     lon::T
     lat::T
-    EclipticCoords{e, T}(lon, lat) where {e, T <: Real} = new(mod2pi(lon), lat)
+    EclipticCoords{e, T}(lon, lat) where {e, T <: Real} = new(mod2pi(lon), checklat(lat))
 end
 EclipticCoords{e}(lon::T, lat::T) where {e, T <: Real} = EclipticCoords{e, float(T)}(lon, lat)
 EclipticCoords{e}(lon::Real, lat::Real) where {e} = EclipticCoords{e}(promote(lon, lat)...)

--- a/src/types.jl
+++ b/src/types.jl
@@ -19,9 +19,21 @@ Every concrete `AbstractSkyCoords` subtype calls this from its inner constructor
 Unlike longitude, which is periodic and safe to wrap with `mod2pi`, an out-of-range latitude
 does not have an unambiguous "wrapped" meaning without also flipping the longitude by π,
 so it is rejected instead.
+
+Number types whose comparisons are undecidable are accepted as is, so uncertainty-propagating
+types (e.g., `MonteCarloMeasurements.Particles` with a distribution straddling a pole) can be
+used without restriction.
 """
 function checklat(lat)
-    -π / 2 <= lat <= π / 2 ||
+    # Some uncertainty-propagating types (e.g., MonteCarloMeasurements.Particles) throw on
+    # comparisons they consider ambiguous, such as a distribution straddling ±π/2. Treat an
+    # undecidable comparison as valid rather than restricting which numeric types can be used.
+    valid = try
+        -π / 2 <= lat <= π / 2
+    catch
+        true
+    end
+    valid ||
         throw(ArgumentError("Latitude/declination must be in [-π/2, π/2] radians, got $(lat)."))
     return lat
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,10 +21,23 @@ rad2arcsec(r) = 3600 * rad2deg(r)
 # tests against astropy.coordinates
 include("astropy.jl")
 
+@testset "domain validation" begin
+    for C in (ICRSCoords, GalCoords, SuperGalCoords, FK5Coords{2000}, EclipticCoords{2000})
+        @test C(0, π / 2) isa C # Poles are valid (closed interval)
+        @test C(0, -π / 2) isa C
+        @test_throws ArgumentError C(0, nextfloat(π / 2))
+        @test_throws ArgumentError C(0, prevfloat(-π / 2))
+        @test_throws ArgumentError C(0, 2)
+        @test_throws ArgumentError C(0, NaN)
+    end
+end
+
 # Test separation between coordinates and conversion with mixed floating types.
 @testset "Separation" begin
     c1 = ICRSCoords(ℯ, pi / 2)
-    c5 = ICRSCoords(ℯ, 1 + pi / 2)
+    # 1 radian past the pole from c1, expressed in-range (dec must be in [-π/2, π/2]).
+    # Going past the pole flips lon by π and reflects dec through π/2.
+    c5 = ICRSCoords(ℯ + pi, pi / 2 - 1)
     @test separation(c1, c5) ≈ separation(c5, c1) ≈ separation(c1, convert(GalCoords, c5)) ≈
         separation(convert(FK5Coords{1980}, c5), c1) ≈ 1
     for T in (GalCoords, FK5Coords{2000}, EclipticCoords{2000})
@@ -156,19 +169,19 @@ end
         @test c_conv3 ≈ c3_conv
     end
 
-    a = ICRSCoords(1, 2)
-    b = GalCoords(1, 2)
+    a = ICRSCoords(1, 1.2)
+    b = GalCoords(1, 1.2)
     a3 = cartesian(a)
     b3 = cartesian(b)
     @test separation(a, b) ≈ separation(a3, b3) ≈ separation(a, b3) ≈ separation(a3, b)
 end
 
 @testset "constructionbase" begin
-    @test setproperties(ICRSCoords(1, 2), ra = 3) == ICRSCoords(3, 2)
-    @test setproperties(GalCoords(1, 2), l = 3) == GalCoords(3, 2)
-    @test setproperties(FK5Coords{2000}(1, 2), ra = 3) == FK5Coords{2000}(3, 2)
-    @test setproperties(EclipticCoords{2000}(1, 2), lon = 3) == EclipticCoords{2000}(3, 2)
-    @test setproperties(cartesian(ICRSCoords(1, 2)), vec = [1.0, 0, 0]) == cartesian(ICRSCoords(0, 0))
+    @test setproperties(ICRSCoords(1, 1.2), ra = 3) == ICRSCoords(3, 1.2)
+    @test setproperties(GalCoords(1, 1.2), l = 3) == GalCoords(3, 1.2)
+    @test setproperties(FK5Coords{2000}(1, 1.2), ra = 3) == FK5Coords{2000}(3, 1.2)
+    @test setproperties(EclipticCoords{2000}(1, 1.2), lon = 3) == EclipticCoords{2000}(3, 1.2)
+    @test setproperties(cartesian(ICRSCoords(1, 1.2)), vec = [1.0, 0, 0]) == cartesian(ICRSCoords(0, 0))
 end
 
 VERSION > v"1.9-DEV" && @testset "Accessors" begin
@@ -243,10 +256,10 @@ end
 
 @testset "equality" begin
     @testset for T in [ICRSCoords, GalCoords, FK5Coords{2000}, EclipticCoords{2000}]
-        c1 = T(1.0, 2.0)
-        c2 = T(1.0, 2.001)
-        c3 = T{Float32}(1.0, 2.0)
-        c4 = T{Float32}(1.0, 2.001)
+        c1 = T(1.0, 1.2)
+        c2 = T(1.0, 1.201)
+        c3 = T{Float32}(1.0, 1.2)
+        c4 = T{Float32}(1.0, 1.201)
         @test c1 == c1
         @test_broken c1 == c3
         @test c1 ≈ c1
@@ -257,8 +270,8 @@ end
         @test c1 ≈ c4  rtol = 1.0e-3
     end
 
-    @test_broken (!(ICRSCoords(1, 2) ≈ FK5Coords{2000}(1, 2)); true)
-    @test_broken (!(FK5Coords{2000}(1, 2) ≈ FK5Coords{1950}(1, 2)); true)
+    @test_broken (!(ICRSCoords(1, 1.2) ≈ FK5Coords{2000}(1, 1.2)); true)
+    @test_broken (!(FK5Coords{2000}(1, 1.2) ≈ FK5Coords{1950}(1, 1.2)); true)
 end
 
 @testset "conversion" begin
@@ -273,11 +286,11 @@ end
 end
 
 VERSION >= v"1.9" && @testset "plotting with Makie" begin
-    coo = ICRSCoords(1, 2)
+    coo = ICRSCoords(1, 1.2)
 
-    @test Makie.convert_arguments(Makie.Scatter, coo) == ([Makie.Point(1, 2)],)
-    @test Makie.convert_arguments(Makie.Scatter, [coo]) == ([Makie.Point(1, 2)],)
-    @test Makie.convert_arguments(Makie.Lines, [coo, coo]) == ([Makie.Point(1, 2), Makie.Point(1, 2)],)
+    @test Makie.convert_arguments(Makie.Scatter, coo) == ([Makie.Point(1, 1.2)],)
+    @test Makie.convert_arguments(Makie.Scatter, [coo]) == ([Makie.Point(1, 1.2)],)
+    @test Makie.convert_arguments(Makie.Lines, [coo, coo]) == ([Makie.Point(1, 1.2), Makie.Point(1, 1.2)],)
     @test Makie.convert_arguments(Makie.Lines, [coo][1:0]) == ([],)
 end
 


### PR DESCRIPTION
## Breaking

Angles outside of the domain (e.g., declination past 90 degrees), now errors:

```julia
julia> ICRSCoords(π/4, π/2 + π/8) # π/8 past the pole
ERROR: ArgumentError: Latitude/declination must be in [-π/2, π/2] radians, got 1.9634954084936207.
```

Before, this would silently pass the pole flipping through:

```julia
julia> ICRSCoords(π/4, π/2 + π/8) # π/8 past the pole
ICRSCoords{Float64}(0.7853981633974483, 1.9634954084936207)
```

Caught in https://github.com/JuliaAstro/SkyCoords.jl/pull/43#discussion_r3585984238