### PR TITLE
feat: Add `FK4Coords` and `FK4NoETerms`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,14 @@ julia> Pkg.add("SkyCoords")
 ## Usage
 
 
-There are currently five supported coordinate systems. The following
+There are currently seven supported coordinate systems. The following
 immutable types are used to represent coordinates in each system:
 
 - `ICRSCoords`: ICRS coordinates system
 - `GalCoords`: Galactic coordinates system
 - `SuperGalCoords`: Super-Galactic coordinate system
+- `FK4Coords`: FK4 coordinates system (with arbitrary Besselian equinox)
+- `FK4NoETerms`: FK4 coordinates system without the E-terms of aberration (with arbitrary Besselian equinox)
 - `FK5Coords`: FK5 coordinates system (with arbitrary equinox)
 - `EclipticCoords`: Ecliptic coordinates system
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -17,6 +17,8 @@ AbstractSkyCoords
 ICRSCoords
 GalCoords
 SuperGalCoords
+FK4Coords
+FK4NoETerms
 FK5Coords
 EclipticCoords
 CartesianCoords

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,12 +23,14 @@ DocTestSetup = :(using SkyCoords)
 ## Usage
 
 
-There are currently five supported coordinate systems. The following
+There are currently seven supported coordinate systems. The following
 immutable types are used to represent coordinates in each system:
 
 - [`ICRSCoords`](@ref): ICRS coordinates system
 - [`GalCoords`](@ref): Galactic coordinates system
 - [`SuperGalCoords`](@ref): Supergalactic coordinates system
+- [`FK4Coords`](@ref): FK4 coordinates system (with arbitrary Besselian equinox)
+- [`FK4NoETerms`](@ref): FK4 coordinates system without the E-terms of aberration (with arbitrary Besselian equinox)
 - [`FK5Coords`](@ref): FK5 coordinates system (with arbitrary equinox)
 - [`EclipticCoords`](@ref): Ecliptic coordinates system
 

--- a/ext/AccessorsExt.jl
+++ b/ext/AccessorsExt.jl
@@ -10,6 +10,10 @@ set(x::EclipticCoords, ::typeof(lon), v) = @set x.lon = v
 set(x::EclipticCoords, ::typeof(lat), v) = @set x.lat = v
 set(x::ICRSCoords, ::typeof(lon), v) = @set x.ra = v
 set(x::ICRSCoords, ::typeof(lat), v) = @set x.dec = v
+set(x::FK4Coords, ::typeof(lon), v) = @set x.ra = v
+set(x::FK4Coords, ::typeof(lat), v) = @set x.dec = v
+set(x::FK4NoETerms, ::typeof(lon), v) = @set x.ra = v
+set(x::FK4NoETerms, ::typeof(lat), v) = @set x.dec = v
 set(x::FK5Coords, ::typeof(lon), v) = @set x.ra = v
 set(x::FK5Coords, ::typeof(lat), v) = @set x.dec = v
 

--- a/ext/DynamicQuantitiesExt.jl
+++ b/ext/DynamicQuantitiesExt.jl
@@ -3,7 +3,7 @@ module DynamicQuantitiesExt
 using DynamicQuantities
 using SkyCoords
 
-_COORDTYPES_LATLON = Union{ICRSCoords, GalCoords, FK5Coords, EclipticCoords}
+_COORDTYPES_LATLON = Union{ICRSCoords, GalCoords, FK4Coords, FK4NoETerms, FK5Coords, EclipticCoords}
 
 (::Type{T})(lon::UnionAbstractQuantity, lat) where {T <: _COORDTYPES_LATLON} = T(ustrip(u"rad", lon), lat)
 (::Type{T})(lon, lat::UnionAbstractQuantity) where {T <: _COORDTYPES_LATLON} = T(lon, ustrip(u"rad", lat))

--- a/ext/UnitfulExt.jl
+++ b/ext/UnitfulExt.jl
@@ -3,7 +3,7 @@ module UnitfulExt
 using Unitful
 using SkyCoords
 
-_COORDTYPES_LATLON = Union{ICRSCoords, GalCoords, FK5Coords, EclipticCoords}
+_COORDTYPES_LATLON = Union{ICRSCoords, GalCoords, FK4Coords, FK4NoETerms, FK5Coords, EclipticCoords}
 
 (::Type{T})(lon::Quantity, lat) where {T <: _COORDTYPES_LATLON} = T(ustrip(u"rad", lon), lat)
 (::Type{T})(lon, lat::Quantity) where {T <: _COORDTYPES_LATLON} = T(lon, ustrip(u"rad", lat))

--- a/src/SkyCoords.jl
+++ b/src/SkyCoords.jl
@@ -1,7 +1,7 @@
 module SkyCoords
 
 import ConstructionBase: constructorof
-using LinearAlgebra: I, norm
+using LinearAlgebra: I, dot, norm, normalize
 using Rotations: RotX, RotXYZ, RotZYZ
 using StaticArrays: SA, SVector
 
@@ -9,6 +9,8 @@ export AbstractSkyCoords,
     ICRSCoords,
     GalCoords,
     SuperGalCoords,
+    FK4Coords,
+    FK4NoETerms,
     FK5Coords,
     EclipticCoords,
     CartesianCoords,
@@ -131,6 +133,16 @@ lonlat(c::AbstractSkyCoords) = (lon(c), lat(c))
 # Abstract away specific field names (ra, dec vs l, b)
 coords2cart(c::AbstractSkyCoords) = coords2cart(lon(c), lat(c))
 
+# Frame transformation of a Cartesian unit vector: `frame_transform(to, from, v)`.
+# This is the single primitive behind every frame change in the package
+# (`convert` reduces to it, for spherical and Cartesian representations alike).
+# For purely rotational systems — every system except FK4Coords — it is simply
+# multiplication by the `rotmat` rotation matrix below. Systems whose transform
+# is not a rotation (FK4Coords with its position-dependent E-terms) override
+# `frame_transform` directly instead of providing a `rotmat`.
+frame_transform(::Type{T}, ::Type{S}, v) where {T <: AbstractSkyCoords, S <: AbstractSkyCoords} =
+    rotmat(T, S) * v
+
 # Rotation matrix between coordinate systems: `rotmat(to, from)`
 # Note that all of these return SMatrix{3,3}{Float64}, regardless of
 # element type of input coordinates.
@@ -167,6 +179,134 @@ rotmat(::Type{<:ICRSCoords}, ::Type{<:SuperGalCoords}) = SUPERGAL_TO_ICRS
     FK5J2000_TO_SUPERGAL * precess_from_j2000(e2)'
 @generated rotmat(::Type{<:FK5Coords{e1}}, ::Type{<:FK5Coords{e2}}) where {e1, e2} =
     precess_from_j2000(e1) * precess_from_j2000(e2)'
+
+# -----------------------------------------------------------------------------
+# FK4 (with E-terms of aberration)
+
+# `FK4NoETerms{e}` (see types.jl) is a purely-rotational system, so it
+# participates in the `rotmat` network like any other type. `FK4Coords` itself
+# cannot, because folding the E-terms in/out is a position-dependent correction
+# rather than a rotation; it overrides `frame_transform` below instead.
+
+# Newcomb precession, valid within the FK4/Besselian system only
+# (FK5 uses the IAU 1976/2000 Julian precession implemented by `precess_from_j2000`).
+# Explanatory Supplement to the Astronomical Almanac (Seidelmann, 1992), as
+# implemented in astropy's `FK4NoETerms._precession_matrix`.
+function newcomb_precession(byear1, byear2)
+    t1 = (byear1 - 1850.0) / 1000.0
+    dt = (byear2 - 1850.0) / 1000.0 - t1
+    dt_over_3600 = dt / 3600
+
+    zeta1 = (0.060 * t1 + 139.720) * t1 + 23035.545
+    zeta2 = -0.27 * t1 + 30.240
+    zeta = ((17.995 * dt + zeta2) * dt + zeta1) * dt_over_3600
+
+    z2 = 109.480 + 0.39 * t1
+    z = ((18.325 * dt + z2) * dt + zeta1) * dt_over_3600
+
+    theta1 = (-0.37 * t1 - 85.29) * t1 + 20051.12
+    theta2 = -0.37 * t1 - 42.65
+    theta = ((-41.8 * dt + theta2) * dt + theta1) * dt_over_3600
+
+    return RotZYZ(deg2rad(z), -deg2rad(theta), deg2rad(zeta))
+end
+
+# Besselian year -> Julian date (365.2421988-day Besselian year)
+besselian_to_jd(byear) = 2433282.4235 + (byear - 1950) * 365.2421988
+
+# Mean obliquity of the ecliptic, IAU 1980 (erfa's `obl80`)
+function mean_obliquity80(jd)
+    t = (jd - 2451545.0) / 36525.0
+    obl = @evalpoly(t, 84381.448, -46.8150, -0.00059, 0.001813)
+    return deg2rad(obl / 3600)
+end
+
+# E-terms of elliptic aberration for a given FK4 equinox (Besselian year).
+# A small (dimensionless, ~1e-4) vector correction in Cartesian space arising
+# from folding the aberration due to the eccentricity of Earth's orbit
+# directly into the FK4 catalog positions. See astropy's `fk4_e_terms`.
+function fk4_eterms(byear)
+    k = deg2rad(0.0056932)
+    jd = besselian_to_jd(byear)
+    t = (jd - besselian_to_jd(1950)) / 36525.0
+    ek = k * ((-0.000000126 * t - 0.00004193) * t + 0.01673011)
+    g = deg2rad((((0.012 * t + 1.65) * t + 6190.67) * t + 1015489.951) / 3600)
+    mekcosg = -ek * cos(g)
+    o = mean_obliquity80(jd)
+    return SA[ek * sin(g), mekcosg * cos(o), mekcosg * sin(o)]
+end
+
+# FK4 (with E-terms) -> FK4NoETerms: closed-form removal.
+remove_eterms(v, byear) = (e = fk4_eterms(byear); normalize(v - e + dot(e, v) * v))
+
+# FK4NoETerms -> FK4 (with E-terms): fixed-point iteration (matches astropy).
+function add_eterms(v, byear)
+    e = fk4_eterms(byear)
+    rhs = e + v
+    w = v
+    for _ in 1:10
+        w = rhs / (1 + dot(e, w))
+    end
+    return normalize(w)
+end
+
+# B1950 -> J2000 frame rotation, Murray 1989 A&A 218,325 eqn 28.
+const B1950_TO_J2000 = SA[
+    0.9999256794956877 -0.0111814832204662 -0.0048590038153592
+    0.0111814832391717 0.9999374848933135 -0.0000271625947142
+    0.0048590037723143 -0.0000271702937440 0.9999881946023742
+]
+
+# Correction accounting for FK4 being a slowly-rotating system, per Julian
+# century of obstime from B1950 (Murray 1989 eqn 29). We take obstime to equal
+# the FK4 equinox, matching astropy's default when no separate obstime is given.
+const FK4_CORR = SA[
+    -0.0026455262 -1.1539918689 2.1111346190
+    1.1540628161 -0.0129042997 0.0236021478
+    -2.1112979048 -0.0056024448 0.0102587734
+] * 1.0e-6
+
+fk4_B_matrix(byear) = B1950_TO_J2000 + FK4_CORR * ((byear - 1950.0) / 100.0)
+
+rotmat(::Type{<:FK4NoETerms{e}}, ::Type{<:FK4NoETerms{e}}) where {e} = I
+
+@generated rotmat(::Type{<:FK5Coords{2000}}, ::Type{<:FK4NoETerms{e}}) where {e} =
+    fk4_B_matrix(e) * newcomb_precession(e, 1950)
+@generated rotmat(::Type{<:FK4NoETerms{e}}, ::Type{<:FK5Coords{2000}}) where {e} =
+    rotmat(FK5Coords{2000}, FK4NoETerms{e})'
+
+@generated rotmat(::Type{T}, ::Type{<:FK4NoETerms{e}}) where {e, T <: AbstractSkyCoords} =
+    rotmat(T, FK5Coords{2000}) * rotmat(FK5Coords{2000}, FK4NoETerms{e})
+@generated rotmat(::Type{<:FK4NoETerms{e}}, ::Type{T}) where {e, T <: AbstractSkyCoords} =
+    rotmat(FK4NoETerms{e}, FK5Coords{2000}) * rotmat(FK5Coords{2000}, T)
+# Disambiguation, and physically correct: precess directly within the
+# Besselian/FK4 system rather than round-tripping through FK5
+# (the B-matrix correction above is a one-time system-level offset,
+# not something to apply twice).
+@generated rotmat(::Type{<:FK4NoETerms{e_to}}, ::Type{<:FK4NoETerms{e_from}}) where {e_to, e_from} =
+    newcomb_precession(e_from, e_to)
+
+# EclipticCoords and FK4NoETerms are the only two types with a generic
+# "fall back to any T <: AbstractSkyCoords" `rotmat` method (both routing
+# through FK5Coords). Without an explicit rule for this specific pair, their
+# two fallbacks are ambiguous with each other.
+@generated rotmat(::Type{<:EclipticCoords{e1}}, ::Type{<:FK4NoETerms{e2}}) where {e1, e2} =
+    rotmat(EclipticCoords{e1}, FK5Coords{e1}) * rotmat(FK5Coords{e1}, FK4NoETerms{e2})
+@generated rotmat(::Type{<:FK4NoETerms{e1}}, ::Type{<:EclipticCoords{e2}}) where {e1, e2} =
+    rotmat(FK4NoETerms{e1}, FK5Coords{2000}) * rotmat(FK5Coords{2000}, EclipticCoords{e2})
+
+# FK4Coords is FK4NoETerms with the E-terms folded in, so its frame transform
+# removes/adds the E-terms around a transform through FK4NoETerms. Because
+# these methods define the `frame_transform` primitive itself, every `convert`
+# — spherical or Cartesian, in either direction — works generically.
+frame_transform(::Type{TO}, ::Type{<:FK4Coords{e}}, v) where {TO <: AbstractSkyCoords, e} =
+    frame_transform(TO, FK4NoETerms{e}, remove_eterms(v, e))
+frame_transform(::Type{<:FK4Coords{e}}, ::Type{FROM}, v) where {e, FROM <: AbstractSkyCoords} =
+    add_eterms(frame_transform(FK4NoETerms{e}, FROM, v), e)
+# disambiguation for the FK4 -> FK4 pair; same-equinox is the identity
+frame_transform(::Type{<:FK4Coords{e_to}}, ::Type{<:FK4Coords{e_from}}, v) where {e_to, e_from} =
+    add_eterms(rotmat(FK4NoETerms{e_to}, FK4NoETerms{e_from}) * remove_eterms(v, e_from), e_to)
+frame_transform(::Type{<:FK4Coords{e}}, ::Type{<:FK4Coords{e}}, v) where {e} = v
 
 # ------------------------------------------------------------------------------
 # Distance between coordinates

--- a/src/SkyCoords.jl
+++ b/src/SkyCoords.jl
@@ -140,8 +140,25 @@ coords2cart(c::AbstractSkyCoords) = coords2cart(lon(c), lat(c))
 # multiplication by the `rotmat` rotation matrix below. Systems whose transform
 # is not a rotation (FK4Coords with its position-dependent E-terms) override
 # `frame_transform` directly instead of providing a `rotmat`.
-frame_transform(::Type{T}, ::Type{S}, v) where {T <: AbstractSkyCoords, S <: AbstractSkyCoords} =
-    rotmat(T, S) * v
+function frame_transform(::Type{T}, ::Type{S}, v) where {T <: AbstractSkyCoords, S <: AbstractSkyCoords}
+    _checkframe(T)
+    return rotmat(T, S) * v
+end
+
+# A type names a coordinate frame when supplying an element type makes it
+# concrete: `ICRSCoords`, `FK5Coords{2000}`, and `ICRSCoords{Float32}` all do;
+# a bare `FK5Coords` or `FK4Coords` (missing its equinox) does not — it
+# satisfies no `T <: FK5Coords{e}` for any single `e`, so it would silently
+# fall past every `rotmat`/`frame_transform` method and fail deep inside
+# `rotmat` with a confusing `MethodError`. Check before the lookup instead.
+# Both checks fold away at compile time on the specialized (valid) paths.
+_isframe(::Type{TC}) where {TC <: AbstractSkyCoords} =
+    isconcretetype(TC) || (TC isa UnionAll && isconcretetype(TC{Float64}))
+_checkframe(::Type{TC}) where {TC <: AbstractSkyCoords} =
+    _isframe(TC) || throw(ArgumentError(
+        "$TC does not fully specify a coordinate system (a required equinox/epoch " *
+        "is missing); fully specify its type parameters, e.g. `$TC{1950}`",
+    ))
 
 # Rotation matrix between coordinate systems: `rotmat(to, from)`
 # Note that all of these return SMatrix{3,3}{Float64}, regardless of

--- a/src/cartesian.jl
+++ b/src/cartesian.jl
@@ -87,7 +87,7 @@ spherical(c::CartesianCoords{TC}) where {TC <: AbstractSkyCoords} = TC(cart2coor
 # specified are honored exactly (the `convert` contract requires returning the
 # requested type); unspecified ones are inferred from the input. Every method
 # reduces to the two orthogonal primitives: representation change
-# (`cartesian`/`spherical`) and frame rotation (`rotmat`).
+# (`cartesian`/`spherical`) and frame change (`frame_transform`).
 
 # No parameters: keep the input frame, change representation only.
 Base.convert(::Type{CartesianCoords}, c::AbstractSkyCoords) = cartesian(c)
@@ -95,17 +95,17 @@ Base.convert(::Type{CartesianCoords}, c::CartesianCoords) = c
 
 # Frame tag specified: rotate. Element type inferred from the rotated vector.
 Base.convert(::Type{CartesianCoords{TC}}, c::AbstractSkyCoords) where {TC <: AbstractSkyCoords} = convert(CartesianCoords{TC}, cartesian(c))
-Base.convert(::Type{CartesianCoords{TC}}, c::CartesianCoords{SC}) where {TC <: AbstractSkyCoords, SC <: AbstractSkyCoords} = CartesianCoords{TC}(rotmat(TC, SC) * vec(c))
+Base.convert(::Type{CartesianCoords{TC}}, c::CartesianCoords{SC}) where {TC <: AbstractSkyCoords, SC <: AbstractSkyCoords} = CartesianCoords{TC}(frame_transform(TC, SC, vec(c)))
 Base.convert(::Type{CartesianCoords{TC}}, c::CartesianCoords{TC}) where {TC <: AbstractSkyCoords} = c
 
 # Frame tag and element type specified: both honored exactly.
 Base.convert(::Type{CartesianCoords{TC, TF}}, c::AbstractSkyCoords) where {TC <: AbstractSkyCoords, TF <: Real} = convert(CartesianCoords{TC, TF}, cartesian(c))
-Base.convert(::Type{CartesianCoords{TC, TF}}, c::CartesianCoords{SC}) where {TC <: AbstractSkyCoords, TF <: Real, SC <: AbstractSkyCoords} = CartesianCoords{TC, TF}(rotmat(TC, SC) * vec(c))
+Base.convert(::Type{CartesianCoords{TC, TF}}, c::CartesianCoords{SC}) where {TC <: AbstractSkyCoords, TF <: Real, SC <: AbstractSkyCoords} = CartesianCoords{TC, TF}(frame_transform(TC, SC, vec(c)))
 Base.convert(::Type{CartesianCoords{TC, TF}}, c::CartesianCoords{TC, TF}) where {TC <: AbstractSkyCoords, TF <: Real} = c
 
 # Spherical target from a Cartesian source: rotate, then change representation.
 function Base.convert(::Type{T}, c::CartesianCoords{SC}) where {T <: AbstractSkyCoords, SC <: AbstractSkyCoords}
-    r = rotmat(T, SC) * vec(c)
+    r = frame_transform(T, SC, vec(c))
     return T(cart2coords(r)...)
 end
 

--- a/src/cartesian.jl
+++ b/src/cartesian.jl
@@ -24,6 +24,7 @@ struct CartesianCoords{TC <: AbstractSkyCoords, TF <: Real} <: AbstractSkyCoords
     vec::SVector{3, TF}
 
     function CartesianCoords{TC, TF}(vec) where {TC <: AbstractSkyCoords, TF <: Real}
+        _checkframe(TC)
         TCF = _eltype(TC)
         if !(TCF === TF || TCF === nothing)
             throw(ArgumentError("Element type $TF conflicts with the frame tag $TC. Use the element-type-free tag $(constructorof(TC)) or the matching element type $TCF"))

--- a/src/types.jl
+++ b/src/types.jl
@@ -127,11 +127,56 @@ EclipticCoords{e, F}(c::AbstractSkyCoords) where {e, F} = convert(EclipticCoords
 constructorof(::Type{<:EclipticCoords{e}}) where {e} = EclipticCoords{e}
 
 
+"""
+    FK4Coords{e, T <: Real} <: AbstractSkyCoords
+    FK4Coords{equinox}(ra, dec)
+
+[B1950 Equatorial Coordinate System](https://en.wikipedia.org/wiki/Epoch_(astronomy)#B1950.0)
+
+The predecessor to [`FK5Coords`](@ref). Like `FK5Coords`, this system is defined relative to the mean equator and equinox of a given epoch, but that epoch is Besselian rather than Julian (traditionally 1950, i.e. B1950). Unlike every other coordinate system in this package, `FK4Coords` also carries the E-terms of elliptic aberration, a small (~20″) position-dependent correction that was folded directly into the original FK4 catalog positions. Because this correction is not a rotation, `FK4Coords` implements its own `frame_transform` methods rather than providing a `rotmat`; all conversions — including through [`CartesianCoords`](@ref) — otherwise work like any other system. See [`FK4NoETerms`](@ref) for the E-terms-free, purely rotational variant.
+
+### Coordinates
+- `ra` - Right ascension in radians (0, 2π)
+- `dec` - Declination in radians (-π/2, π/2)
+"""
+struct FK4Coords{e, T <: Real} <: AbstractSkyCoords
+    ra::T
+    dec::T
+    FK4Coords{e, T}(ra, dec) where {T <: Real, e} = new(mod2pi(ra), dec)
+end
+FK4Coords{e}(ra::T, dec::T) where {e, T <: Real} = FK4Coords{e, float(T)}(ra, dec)
+FK4Coords{e}(ra::Real, dec::Real) where {e} = FK4Coords{e}(promote(ra, dec)...)
+FK4Coords{e}(c::T) where {e, T <: AbstractSkyCoords} = convert(FK4Coords{e}, c)
+FK4Coords{e, F}(c::T) where {e, F, T <: AbstractSkyCoords} = convert(FK4Coords{e, F}, c)
+constructorof(::Type{<:FK4Coords{e}}) where {e} = FK4Coords{e}
+
+
+"""
+    FK4NoETerms{e, T <: Real} <: AbstractSkyCoords
+    FK4NoETerms{equinox}(ra, dec)
+
+[`FK4Coords`](@ref) with the E-terms of elliptic aberration removed, leaving a purely rotational equatorial system defined relative to the mean equator and equinox of a given Besselian epoch (traditionally 1950, i.e. B1950). This is astropy's `FK4NoETerms` frame.
+
+### Coordinates
+- `ra` - Right ascension in radians (0, 2π)
+- `dec` - Declination in radians (-π/2, π/2)
+"""
+struct FK4NoETerms{e, T <: Real} <: AbstractSkyCoords
+    ra::T
+    dec::T
+    FK4NoETerms{e, T}(ra, dec) where {T <: Real, e} = new(mod2pi(ra), dec)
+end
+FK4NoETerms{e}(ra::T, dec::T) where {e, T <: Real} = FK4NoETerms{e, float(T)}(ra, dec)
+FK4NoETerms{e}(ra::Real, dec::Real) where {e} = FK4NoETerms{e}(promote(ra, dec)...)
+FK4NoETerms{e}(c::T) where {e, T <: AbstractSkyCoords} = convert(FK4NoETerms{e}, c)
+FK4NoETerms{e, F}(c::T) where {e, F, T <: AbstractSkyCoords} = convert(FK4NoETerms{e, F}, c)
+constructorof(::Type{<:FK4NoETerms{e}}) where {e} = FK4NoETerms{e}
+
 # Scalar coordinate conversions
 Base.convert(::Type{T}, c::T) where {T <: AbstractSkyCoords} = c
 
 function Base.convert(::Type{T}, c::S) where {T <: AbstractSkyCoords, S <: AbstractSkyCoords}
-    r = rotmat(T, S) * coords2cart(c)
+    r = frame_transform(T, S, coords2cart(c))
     lon, lat = cart2coords(r)
     return T(lon, lat)
 end
@@ -146,5 +191,7 @@ Base.hash(c::AbstractSkyCoords, h::UInt) = hash(lonlat(c), hash(constructorof(ty
 Base.isapprox(a::ICRSCoords, b::ICRSCoords; kwargs...) = isapprox(SVector(lon(a), lat(a)), SVector(lon(b), lat(b)); kwargs...)
 Base.isapprox(a::GalCoords, b::GalCoords; kwargs...) = isapprox(SVector(lon(a), lat(a)), SVector(lon(b), lat(b)); kwargs...)
 Base.isapprox(a::SuperGalCoords, b::SuperGalCoords; kwargs...) = isapprox(SVector(lon(a), lat(a)), SVector(lon(b), lat(b)); kwargs...)
+Base.isapprox(a::FK4Coords{e}, b::FK4Coords{e}; kwargs...) where {e} = isapprox(SVector(lon(a), lat(a)), SVector(lon(b), lat(b)); kwargs...)
+Base.isapprox(a::FK4NoETerms{e}, b::FK4NoETerms{e}; kwargs...) where {e} = isapprox(SVector(lon(a), lat(a)), SVector(lon(b), lat(b)); kwargs...)
 Base.isapprox(a::FK5Coords{e}, b::FK5Coords{e}; kwargs...) where {e} = isapprox(SVector(lon(a), lat(a)), SVector(lon(b), lat(b)); kwargs...)
 Base.isapprox(a::EclipticCoords{e}, b::EclipticCoords{e}; kwargs...) where {e} = isapprox(SVector(lon(a), lat(a)), SVector(lon(b), lat(b)); kwargs...)

--- a/test/astropy.jl
+++ b/test/astropy.jl
@@ -10,6 +10,8 @@ const lats = pi .* (rand(rng, N) .- 0.5) # (-π, π)
 
 # get the astropy frames from the julia type
 astropy_conversion(::Type{<:ICRSCoords}) = apc.ICRS
+astropy_conversion(::Type{<:FK4Coords{F}}) where {F} = apc.FK4(equinox = "B$F")
+astropy_conversion(::Type{<:FK4NoETerms{F}}) where {F} = apc.FK4NoETerms(equinox = "B$F")
 astropy_conversion(::Type{<:FK5Coords{F}}) where {F} = apc.FK5(equinox = "J$F")
 astropy_conversion(::Type{<:GalCoords}) = apc.Galactic
 astropy_conversion(::Type{<:SuperGalCoords}) = apc.Supergalactic
@@ -46,6 +48,10 @@ end
 
     systems = (
         ICRSCoords{F},
+        FK4Coords{1950, F},
+        FK4Coords{1975, F},
+        FK4NoETerms{1950, F},
+        FK4NoETerms{1975, F},
         FK5Coords{2000, F},
         FK5Coords{1975, F},
         GalCoords{F},
@@ -54,7 +60,19 @@ end
         EclipticCoords{1975, F},
     )
     @testset "$IN_SYS --> $OUT_SYS" for IN_SYS in systems, OUT_SYS in systems
-        atol = IN_SYS <: EclipticCoords || OUT_SYS <: EclipticCoords ? 1.0e-3 : 0
+        # FK4Coords/FK4NoETerms need a small amount of slack against (Super)Galactic:
+        # astropy routes FK4->Galactic through a *different* (legacy, B1950-based)
+        # galactic pole than the J2000-based one used everywhere else in this package
+        # (see comment on FK5J2000_TO_GAL), so precessing an off-equinox FK4/FK4NoETerms
+        # to Galactic picks up a small (sub-arcsecond) discrepancy between the two
+        # conventions. This is independent of the E-terms, so it affects both types.
+        atol = if IN_SYS <: EclipticCoords || OUT_SYS <: EclipticCoords
+            1.0e-3
+        elseif IN_SYS <: FK4Coords || OUT_SYS <: FK4Coords || IN_SYS <: FK4NoETerms || OUT_SYS <: FK4NoETerms
+            1.0e-5
+        else
+            0
+        end
         test_against_astropy(IN_SYS, OUT_SYS; atol)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -177,6 +177,38 @@ end
     a3 = cartesian(a)
     b3 = cartesian(b)
     @test separation(a, b) ≈ separation(a3, b3) ≈ separation(a, b3) ≈ separation(a3, b)
+
+    # FK4Coords's E-terms correction is not a rotation, but `frame_transform`
+    # doesn't require one: all four Cartesian/spherical directions must agree
+    # with converting spherically and wrapping/unwrapping around that, not
+    # just avoid throwing.
+    fk4 = FK4Coords{1950}(0.4, -0.1)
+    other = ICRSCoords(0.2, 0.3)
+    @test convert(FK4Coords{1975}, cartesian(other)) ≈ convert(FK4Coords{1975}, other)
+    @test convert(CartesianCoords{ICRSCoords}, fk4) ≈ cartesian(convert(ICRSCoords, fk4))
+    @test convert(CartesianCoords{ICRSCoords}, cartesian(fk4)) ≈ cartesian(convert(ICRSCoords, fk4))
+    @test convert(CartesianCoords{FK4Coords{1950}}, cartesian(other)) ≈ cartesian(convert(FK4Coords{1950}, other))
+    @test convert(CartesianCoords{FK4Coords{1975}}, cartesian(fk4)) ≈ cartesian(convert(FK4Coords{1975}, fk4))
+
+    # a target that doesn't fully specify a frame (a required equinox is
+    # missing) raises a clear error instead of a confusing `rotmat`
+    # MethodError, regardless of source and pathway
+    @test_throws ArgumentError convert(FK4Coords, other)
+    @test_throws ArgumentError convert(FK4NoETerms, other)
+    @test_throws ArgumentError convert(FK5Coords, other)
+    @test_throws ArgumentError convert(EclipticCoords, other)
+    @test_throws ArgumentError convert(FK4NoETerms, fk4)
+    @test_throws ArgumentError convert(FK4Coords, cartesian(other))
+    @test_throws ArgumentError convert(FK4NoETerms, cartesian(other))
+    @test_throws ArgumentError convert(CartesianCoords{FK4Coords}, cartesian(other))
+    @test_throws ArgumentError convert(CartesianCoords{FK4NoETerms}, cartesian(other))
+    @test_throws ArgumentError convert(CartesianCoords{FK5Coords}, other)
+    @test_throws ArgumentError CartesianCoords{FK4Coords}(1, 0, 0)
+
+    # an instance that already matches a bare/partial target converts by
+    # identity, following the usual Base convention (like `convert(Integer, 3)`)
+    @test convert(FK4Coords, fk4) === fk4
+    @test convert(FK5Coords, FK5Coords{2000}(1, 2)) === FK5Coords{2000}(1, 2)
 end
 
 @testset "CartesianCoords type parameters ($CT, $TF)" for TF in (Float32, Float64), CT in (ICRSCoords, GalCoords, FK5Coords{2000}, FK4Coords{1950}, FK4NoETerms{1950})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,7 @@ include("astropy.jl")
     c5 = ICRSCoords(ℯ, 1 + pi / 2)
     @test separation(c1, c5) ≈ separation(c5, c1) ≈ separation(c1, convert(GalCoords, c5)) ≈
         separation(convert(FK5Coords{1980}, c5), c1) ≈ 1
-    for T in (GalCoords, FK5Coords{2000}, EclipticCoords{2000})
+    for T in (GalCoords, FK4Coords{1950}, FK4NoETerms{1950}, FK5Coords{2000}, EclipticCoords{2000})
         c2 = convert(T{Float32}, c1)
         c3 = convert(T{Float64}, c1)
         c4 = convert(T{BigFloat}, c1)
@@ -37,13 +37,27 @@ include("astropy.jl")
         @test isapprox(c2, c3, rtol = sqrt(eps(Float32)))
         @test isapprox(c3, c4, rtol = sqrt(eps(Float64)))
         c6 = convert(T, c5)
-        @test separation(c3, c6) ≈ separation(c6, c3) ≈ 1
+        # FK4Coords's E-terms of aberration are a position-dependent (non-isometric)
+        # correction, so unlike the other, purely-rotational systems, angular
+        # separations computed directly in FK4Coords are not exactly preserved
+        # relative to ICRS. This is expected (astropy's FK4 shows the same
+        # ~1e-6 discrepancy for these near-pole points), so it needs a looser tolerance here.
+        if T <: FK4Coords
+            @test isapprox(separation(c3, c6), separation(c6, c3); rtol = 1.0e-6)
+            @test isapprox(separation(c3, c6), 1; rtol = 1.0e-6)
+        else
+            @test separation(c3, c6) ≈ separation(c6, c3) ≈ 1
+        end
     end
 end
 
 @testset "string construction" for C in [
         ICRSCoords,
         GalCoords,
+        FK4Coords{1950},
+        FK4Coords{1975},
+        FK4NoETerms{1950},
+        FK4NoETerms{1975},
         FK5Coords{2000},
         FK5Coords{1970},
         EclipticCoords{2000},
@@ -74,7 +88,7 @@ end
     @test position_angle(c1, c4) ≈ 0
 
     # types
-    for T in [ICRSCoords, GalCoords, FK5Coords{2000}, EclipticCoords{2000}]
+    for T in [ICRSCoords, GalCoords, FK4Coords{1950}, FK4NoETerms{1950}, FK5Coords{2000}, EclipticCoords{2000}]
         c1 = T(0, 0)
         c2 = T(deg2rad(1), 0)
         @test position_angle(c1, c2) ≈ π / 2
@@ -82,7 +96,7 @@ end
 end
 
 
-@testset "Offset ($T1, $T2)" for T1 in [ICRSCoords, GalCoords, FK5Coords{2000}, EclipticCoords{2000}], T2 in [ICRSCoords, GalCoords, FK5Coords{2000}, EclipticCoords{2000}]
+@testset "Offset ($T1, $T2)" for T1 in [ICRSCoords, GalCoords, FK4Coords{1950}, FK4NoETerms{1950}, FK5Coords{2000}, EclipticCoords{2000}], T2 in [ICRSCoords, GalCoords, FK4Coords{1950}, FK4NoETerms{1950}, FK5Coords{2000}, EclipticCoords{2000}]
     # simple integration tests, depend that separation and position_angle are accurate
     c1s = [
         T1(0, -π / 2), # south pole
@@ -132,7 +146,9 @@ end
 end
 
 @testset "cartesian" begin
-    for CT in [ICRSCoords, FK5Coords{2000}, FK5Coords{1975}, EclipticCoords{2000}, EclipticCoords{1975}, GalCoords]
+    # FK4Coords participates like every other system: its E-terms correction is
+    # not a rotation, but `frame_transform` doesn't require one.
+    for CT in [ICRSCoords, FK4Coords{1950}, FK4NoETerms{1950}, FK4NoETerms{1975}, FK5Coords{2000}, FK5Coords{1975}, EclipticCoords{2000}, EclipticCoords{1975}, GalCoords]
         @test cartesian(CT(0, 0)) |> vec ≈ [1, 0, 0]
         @test cartesian(CT(0, π / 2)) |> vec ≈ [0, 0, 1]
         @test cartesian(CT(π / 2, 0)) |> vec ≈ [0, 1, 0]
@@ -163,7 +179,7 @@ end
     @test separation(a, b) ≈ separation(a3, b3) ≈ separation(a, b3) ≈ separation(a3, b)
 end
 
-@testset "CartesianCoords type parameters ($CT, $TF)" for TF in (Float32, Float64), CT in (ICRSCoords, GalCoords, FK5Coords{2000})
+@testset "CartesianCoords type parameters ($CT, $TF)" for TF in (Float32, Float64), CT in (ICRSCoords, GalCoords, FK5Coords{2000}, FK4Coords{1950}, FK4NoETerms{1950})
     c = CT{TF}(0.1, 0.2)
 
     # canonical form: element-type-free frame tag, element type carried by TF only
@@ -229,13 +245,15 @@ end
 @testset "constructionbase" begin
     @test setproperties(ICRSCoords(1, 2), ra = 3) == ICRSCoords(3, 2)
     @test setproperties(GalCoords(1, 2), l = 3) == GalCoords(3, 2)
+    @test setproperties(FK4Coords{1950}(1, 2), ra = 3) == FK4Coords{1950}(3, 2)
+    @test setproperties(FK4NoETerms{1950}(1, 2), ra = 3) == FK4NoETerms{1950}(3, 2)
     @test setproperties(FK5Coords{2000}(1, 2), ra = 3) == FK5Coords{2000}(3, 2)
     @test setproperties(EclipticCoords{2000}(1, 2), lon = 3) == EclipticCoords{2000}(3, 2)
     @test setproperties(cartesian(ICRSCoords(1, 2)), vec = [1.0, 0, 0]) == cartesian(ICRSCoords(0, 0))
 end
 
 VERSION > v"1.9-DEV" && @testset "Accessors" begin
-    @testset for c in (ICRSCoords(1, 0.5), FK5Coords{2000}(1, 0.5), GalCoords(1, 0.5), EclipticCoords{2000}(1, 0.5))
+    @testset for c in (ICRSCoords(1, 0.5), FK4Coords{1950}(1, 0.5), FK4NoETerms{1950}(1, 0.5), FK5Coords{2000}(1, 0.5), GalCoords(1, 0.5), EclipticCoords{2000}(1, 0.5))
         Accessors.test_getset_laws(lon, c, 1.5, 0.123)
         Accessors.test_getset_laws(lat, c, 1.5, 0.123)
 
@@ -259,6 +277,8 @@ end
 VERSION > v"1.9-DEV" && @testset "Unitful" begin
     @test ICRSCoords(1u"rad", 0.5) === ICRSCoords(1, 0.5)
     @test GalCoords(1u"rad", 0.5u"rad") === GalCoords(1, 0.5)
+    @test FK4Coords{1950}(1u"°", 0.5) === FK4Coords{1950}(deg2rad(1), 0.5)
+    @test FK4NoETerms{1950}(1u"°", 0.5) === FK4NoETerms{1950}(deg2rad(1), 0.5)
     @test FK5Coords{2000}(1u"°", 0.5) === FK5Coords{2000}(deg2rad(1), 0.5)
     @test EclipticCoords{2000}(1u"°", 0.5u"°") === EclipticCoords{2000}(deg2rad(1), deg2rad(0.5))
 
@@ -282,6 +302,8 @@ VERSION > v"1.9-DEV" && @testset "DynamicQuantities" begin
     # Construction from quantities strips to plain radians (=== holds for the underlying Float64 fields).
     @test ICRSCoords(1us"rad", 0.5) === ICRSCoords(1, 0.5)
     @test GalCoords(1us"rad", 0.5us"rad") === GalCoords(1, 0.5)
+    @test FK4Coords{1950}(1us"deg", 0.5) === FK4Coords{1950}(deg2rad(1), 0.5)
+    @test FK4NoETerms{1950}(1us"deg", 0.5) === FK4NoETerms{1950}(deg2rad(1), 0.5)
     @test FK5Coords{2000}(1us"deg", 0.5) === FK5Coords{2000}(deg2rad(1), 0.5)
     @test EclipticCoords{2000}(1us"deg", 0.5us"deg") === EclipticCoords{2000}(deg2rad(1), deg2rad(0.5))
 
@@ -305,7 +327,7 @@ VERSION > v"1.9-DEV" && @testset "DynamicQuantities" begin
 end
 
 @testset "equality" begin
-    @testset for T in [ICRSCoords, GalCoords, FK5Coords{2000}, EclipticCoords{2000}]
+    @testset for T in [ICRSCoords, GalCoords, FK4Coords{1950}, FK4NoETerms{1950}, FK5Coords{2000}, EclipticCoords{2000}]
         c1 = T(1.0, 2.0)
         c2 = T(1.0, 2.001)
         c3 = T{Float32}(1.0, 2.0)
@@ -343,7 +365,7 @@ end
 end
 
 @testset "conversion" begin
-    systems = (ICRSCoords, FK5Coords{2000}, FK5Coords{1975}, EclipticCoords{2000}, EclipticCoords{1975}, GalCoords)
+    systems = (ICRSCoords, FK4Coords{1950}, FK4Coords{1975}, FK4NoETerms{1950}, FK4NoETerms{1975}, FK5Coords{2000}, FK5Coords{1975}, EclipticCoords{2000}, EclipticCoords{1975}, GalCoords)
     for IN_SYS in systems, OUT_SYS in systems
         coord_in = IN_SYS(rand(rng), rand(rng))
         coord_out = convert(OUT_SYS, coord_in)
@@ -362,7 +384,10 @@ VERSION >= v"1.9" && @testset "plotting with Makie" begin
     @test Makie.convert_arguments(Makie.Lines, [coo][1:0]) == ([],)
 end
 
-VERSION >= v"1.9" && @testset "Matching ($T1, $T2)" for T1 in [ICRSCoords, GalCoords, FK5Coords{2000}, EclipticCoords{2000}], T2 in [ICRSCoords, GalCoords, FK5Coords{2000}, EclipticCoords{2000}]
+# FK4Coords is included here even though matching goes through
+# CartesianCoords{ICRSCoords} internally: `frame_transform` handles its
+# non-rotational E-terms correction on the Cartesian pathway too.
+VERSION >= v"1.9" && @testset "Matching ($T1, $T2)" for T1 in [ICRSCoords, GalCoords, FK5Coords{2000}, EclipticCoords{2000}, FK4Coords{1950}, FK4NoETerms{1950}], T2 in [ICRSCoords, GalCoords, FK5Coords{2000}, EclipticCoords{2000}, FK4Coords{1950}, FK4NoETerms{1950}]
     ## data generation
     N = 1000
     lons = 2pi .* rand(rng, N) # (0, 2π)


### PR DESCRIPTION
Adds `FK4Coords` and `FK4NoETerms`, closing the `FK4` half of #8 (`EclipticCoords` was added in #46).

- **`FK4Coords{equinox}`**: The full FK4 equatorial system (astropy's `FK4`), including the E-terms of elliptic aberration, a small (~20″), position-dependent correction folded into the original FK4 catalog positions. This is the historically correct FK4, not the simplified E-terms-free approximation.
- **`FK4NoETerms{equinox}`**: FK4 with the E-terms removed (astropy's `FK4NoETerms`). A purely rotational system, useful on its own and as the intermediate frame `FK4Coords` converts through.

Both are parameterized by an arbitrary Besselian equinox, the same way `FK5Coords` / `EclipticCoords` are parameterized by an arbitrary equinox (e.g. `FK4Coords{1950}`, `FK4NoETerms{1975}`).

## The design problem, and the fix

Every other system in this package converts through a pure rotation (`rotmat`), which is what lets `convert` be one generic function. The E-terms are a position-dependent vector correction, not a rotation, so earlier revisions of this PR routed around the generic machinery. First, with custom `Base.convert` methods plus error guards keeping FK4 off the `CartesianCoords` pathway, later with a redirect through `spherical`. In both cases, the special cases (and their disambiguators) piled up.

After #105, every `convert` method (spherical and Cartesian) and every type-parameter spelling reduces to a single frame-change step. And the E-terms code already operates on Cartesian vectors (`remove_eterms(v, e)` / `add_eterms(v, e)`): FK4 was never incompatible with the Cartesian pathway, its transform just isn't a matrix multiply. So this PR promotes that frame-change step from a matrix to a function:

```julia
# The one primitive behind every frame change. Rotational systems hit the default.
frame_transform(::Type{T}, ::Type{S}, v) = rotmat(T, S) * v
```

and `FK4Coords` overrides it with exactly its physics, right next to that physics:

```julia
frame_transform(::Type{TO}, ::Type{<:FK4Coords{e}}, v)  = frame_transform(TO, FK4NoETerms{e}, remove_eterms(v, e))
frame_transform(::Type{<:FK4Coords{e}}, ::Type{FROM}, v) = add_eterms(frame_transform(FK4NoETerms{e}, FROM, v), e)
# FK4 -> FK4 disambiguation, same-equinox is the exact identity
frame_transform(::Type{<:FK4Coords{e_to}}, ::Type{<:FK4Coords{e_from}}, v) =
    add_eterms(rotmat(FK4NoETerms{e_to}, FK4NoETerms{e_from}) * remove_eterms(v, e_from), e_to)
frame_transform(::Type{<:FK4Coords{e}}, ::Type{<:FK4Coords{e}}, v) = v
```

`FK4NoETerms` is purely rotational and participates in the `rotmat` network like any other system.

What that buys:

- **No special-case conversion rules.** There are no FK4-specific `convert` methods and no error guards. `src/cartesian.jl` contains zero FK4-specific code (its only change is the `rotmat(T, S) * v` --> `frame_transform(T, S, v)` rename), and `types.jl` gains only the two struct definitions.
- **FK4 is a first-class citizen instead of a documented exception.** `cartesian`, `CartesianCoords` conversions in both directions, and KDTree matching all work for `FK4Coords`. Roundtrips like ICRS --> FK4 --> ICRS and the pure-Cartesian FK4 --> Gal --> FK4 loop are exact to `atol = 1e-12`.
- **Same-equinox FK4 --> FK4 is an exact identity**, mirroring the `rotmat(T, T) = I` convention.
- **A recipe for future non-rotational frames**: define the physics, override `frame_transform`, and every conversion spelling works. Nothing else in the package needs to know the transform isn't a matrix.

## Clear errors for equinox-less targets

A bare `FK4Coords`/`FK4NoETerms` target (no equinox) satisfies no `T <: FK4Coords{e}` for any single `e`, so it would silently fall past every
method and die deep inside `rotmat` with a confusing `MethodError`. Since every conversion now passes through `frame_transform`, one check at that primitive (plus one in the `CartesianCoords` inner constructor for direct construction) covers every pathway. This also fixes the same long-standing failure mode for `FK5Coords` and `EclipticCoords` too:

```julia-repl
julia> convert(FK5Coords, c)
ERROR: ArgumentError: FK5Coords does not fully specify a coordinate system (a required equinox/epoch is missing); fully specify its type parameters, e.g. `FK5Coords{1950}`
```

An instance that already matches a bare/partial target still converts by identity (`convert(FK4Coords, fk4) === fk4`), following the usual Base convention (like `convert(Integer, 3)`).

## Physics

- Newcomb precession within the Besselian system (Explanatory Supplement 1992, matching astropy's `FK4NoETerms._precession_matrix`).
- B1950 --> J2000 rotation and the slow-rotation correction from Murray 1989 (A&A 218, 325, eqns 28–29), with obstime taken equal to the equinox, matching astropy's default.
- E-terms removal in closed form and re-addition by fixed-point iteration, matching astropy's `fk4_e_terms` and transform functions.