### PR TITLE
typo: Type binding

### DIFF
--- a/src/cartesian.jl
+++ b/src/cartesian.jl
@@ -47,7 +47,7 @@ Returns the spherical representation of the coordinate `c`. Coordinate arguments
 spherical(c::AbstractSkyCoords) = c
 spherical(c::CartesianCoords{T}) where {T <: AbstractSkyCoords} = T(cart2coords(vec(c))...)
 
-Base.convert(::Type{<:T}, c::CartesianCoords{S}) where {T <: AbstractSkyCoords, S <: AbstractSkyCoords} =
+Base.convert(::Type{T}, c::CartesianCoords{S}) where {T <: AbstractSkyCoords, S <: AbstractSkyCoords} =
     spherical(convert(CartesianCoords{T}, c))
 Base.convert(::Type{<:CartesianCoords{T}}, c::S) where {T <: AbstractSkyCoords, S <: AbstractSkyCoords} =
     convert(CartesianCoords{T}, cartesian(c))


### PR DESCRIPTION
Small typo led to a type not binding, creating weird errors when trying to convert coords:

**Before:**

```julia
julia> ICRSCoords(0.1, 0.2) |> cartesian |> GalCoords
ERROR: UndefVarError: `T` not defined in static parameter matching
Suggestion: run Test.detect_unbound_args to detect method arguments that do not fully constrain a type parameter.
Stacktrace:
 [1] convert(::Type{GalCoords}, c::CartesianCoords{ICRSCoords{Float64}, Float64})
   @ SkyCoords ~/projects/bak/SkyCoords.jl/src/cartesian.jl:55
 [2] GalCoords
   @ ~/projects/bak/SkyCoords.jl/src/types.jl:52 [inlined]
 [3] |>(x::CartesianCoords{ICRSCoords{Float64}, Float64}, f::Type{GalCoords})
   @ Base ./operators.jl:972
 [4] top-level scope
   @ REPL[4]:1
```

**After:**

```julia
julia> ICRSCoords(0.1, 0.2) |> cartesian |> GalCoords
GalCoords{Float64}(1.9519027481021605, -0.8865770182454621)
```