### PR TITLE
fix: Resolve coord ambiguities

### DIFF
--- a/ext/DynamicQuantitiesExt.jl
+++ b/ext/DynamicQuantitiesExt.jl
@@ -3,11 +3,20 @@ module DynamicQuantitiesExt
 using DynamicQuantities
 using SkyCoords
 
-_COORDTYPES_LATLON = Union{ICRSCoords, GalCoords, FK5Coords, EclipticCoords}
+_COORDTYPES_LATLON = Union{ICRSCoords, GalCoords, SuperGalCoords, FK5Coords, EclipticCoords}
 
-(::Type{T})(lon::UnionAbstractQuantity, lat) where {T <: _COORDTYPES_LATLON} = T(ustrip(u"rad", lon), lat)
-(::Type{T})(lon, lat::UnionAbstractQuantity) where {T <: _COORDTYPES_LATLON} = T(lon, ustrip(u"rad", lat))
-(::Type{T})(lon::UnionAbstractQuantity, lat::UnionAbstractQuantity) where {T <: _COORDTYPES_LATLON} = T(ustrip(u"rad", lon), ustrip(u"rad", lat))
+# `AbstractRealQuantity` is deliberately excluded from the quantity slots: it
+# subtypes `Real`, so accepting it here would make these methods ambiguous
+# against the Real-typed coordinate constructors. `RealQuantity` angles are
+# not supported for construction; use `Quantity` or plain radians.
+const _QUANTITY_NOT_REAL = Union{AbstractQuantity, AbstractGenericQuantity}
+
+# Every slot is typed (rather than `Any`) so these methods stay disjoint from
+# the Real-typed coordinate constructors and from the Unitful extension,
+# keeping dispatch free of ambiguities.
+(::Type{T})(lon::_QUANTITY_NOT_REAL, lat::Union{Real, UnionAbstractQuantity}) where {T <: _COORDTYPES_LATLON} = T(ustrip(u"rad", lon), lat)
+(::Type{T})(lon::Union{Real, UnionAbstractQuantity}, lat::_QUANTITY_NOT_REAL) where {T <: _COORDTYPES_LATLON} = T(lon, ustrip(u"rad", lat))
+(::Type{T})(lon::_QUANTITY_NOT_REAL, lat::_QUANTITY_NOT_REAL) where {T <: _COORDTYPES_LATLON} = T(ustrip(u"rad", lon), ustrip(u"rad", lat))
 
 SkyCoords.lon(u::UnionAbstractQuantity, c) = SkyCoords.lon(c) * u"rad" |> u
 SkyCoords.lat(u::UnionAbstractQuantity, c) = SkyCoords.lat(c) * u"rad" |> u

--- a/ext/UnitfulExt.jl
+++ b/ext/UnitfulExt.jl
@@ -3,10 +3,13 @@ module UnitfulExt
 using Unitful
 using SkyCoords
 
-_COORDTYPES_LATLON = Union{ICRSCoords, GalCoords, FK5Coords, EclipticCoords}
+_COORDTYPES_LATLON = Union{ICRSCoords, GalCoords, SuperGalCoords, FK5Coords, EclipticCoords}
 
-(::Type{T})(lon::Quantity, lat) where {T <: _COORDTYPES_LATLON} = T(ustrip(u"rad", lon), lat)
-(::Type{T})(lon, lat::Quantity) where {T <: _COORDTYPES_LATLON} = T(lon, ustrip(u"rad", lat))
+# Every slot is typed (`Union{Real, Quantity}` rather than `Any`) so these
+# methods stay disjoint from the Real-typed coordinate constructors and from
+# the DynamicQuantities extension, keeping dispatch free of ambiguities.
+(::Type{T})(lon::Quantity, lat::Union{Real, Quantity}) where {T <: _COORDTYPES_LATLON} = T(ustrip(u"rad", lon), lat)
+(::Type{T})(lon::Union{Real, Quantity}, lat::Quantity) where {T <: _COORDTYPES_LATLON} = T(lon, ustrip(u"rad", lat))
 (::Type{T})(lon::Quantity, lat::Quantity) where {T <: _COORDTYPES_LATLON} = T(ustrip(u"rad", lon), ustrip(u"rad", lat))
 
 SkyCoords.lon(u::Unitful.Units, c) = SkyCoords.lon(c) * u"rad" |> u

--- a/src/cartesian.jl
+++ b/src/cartesian.jl
@@ -18,7 +18,7 @@ CartesianCoords{TC}(args::Real...) where {TC} = CartesianCoords{TC}(SVector(floa
 CartesianCoords{TC}(vec::AbstractVector{TF}) where {TC, TF} = CartesianCoords{TC, TF}(vec)
 CartesianCoords(c::AbstractSkyCoords) = convert(CartesianCoords, c)
 CartesianCoords{TC}(c::AbstractSkyCoords) where {TC} = convert(CartesianCoords{TC}, c)
-CartesianCoords{TC, TF}(c::AbstractSkyCoords) where {TC <: AbstractSkyCoords, TF} = convert(CartesianCoords{TC, TF}, c)
+CartesianCoords{TC, TF}(c::AbstractSkyCoords) where {TC <: AbstractSkyCoords, TF <: Real} = convert(CartesianCoords{TC, TF}, c)
 constructorof(::Type{<:CartesianCoords{TC}}) where {TC} = CartesianCoords{TC}
 
 Base.vec(c::CartesianCoords) = c.vec

--- a/src/types.jl
+++ b/src/types.jl
@@ -23,7 +23,7 @@ This is the current standard adopted by the International Astronomical Union not
 struct ICRSCoords{T <: Real} <: AbstractSkyCoords
     ra::T
     dec::T
-    ICRSCoords{T}(ra, dec) where {T <: Real} = new(mod2pi(ra), dec)
+    ICRSCoords{T}(ra::Real, dec::Real) where {T <: Real} = new(mod2pi(ra), dec)
 end
 ICRSCoords(ra::T, dec::T) where {T <: Real} = ICRSCoords{float(T)}(ra, dec)
 ICRSCoords(ra::Real, dec::Real) = ICRSCoords(promote(ra, dec)...)
@@ -45,7 +45,7 @@ This coordinate system is defined based on the projection of the Milky Way galax
 struct GalCoords{T <: Real} <: AbstractSkyCoords
     l::T
     b::T
-    GalCoords{T}(l, b) where {T <: Real} = new(mod2pi(l), b)
+    GalCoords{T}(l::Real, b::Real) where {T <: Real} = new(mod2pi(l), b)
 end
 GalCoords(l::T, b::T) where {T <: Real} = GalCoords{float(T)}(l, b)
 GalCoords(l::Real, b::Real) = GalCoords(promote(l, b)...)
@@ -67,7 +67,7 @@ The supergalactic plane as so-far observed is more or less perpendicular to the 
 struct SuperGalCoords{T <: Real} <: AbstractSkyCoords
     l::T
     b::T
-    SuperGalCoords{T}(l, b) where {T <: Real} = new(mod2pi(l), b)
+    SuperGalCoords{T}(l::Real, b::Real) where {T <: Real} = new(mod2pi(l), b)
 end
 SuperGalCoords(l::T, b::T) where {T <: Real} = SuperGalCoords{float(T)}(l, b)
 SuperGalCoords(l::Real, b::Real) = SuperGalCoords(promote(l, b)...)
@@ -95,7 +95,7 @@ frame.
 struct FK5Coords{e, T <: Real} <: AbstractSkyCoords
     ra::T
     dec::T
-    FK5Coords{e, T}(ra, dec) where {T <: Real, e} = new(mod2pi(ra), dec)
+    FK5Coords{e, T}(ra::Real, dec::Real) where {T <: Real, e} = new(mod2pi(ra), dec)
 end
 FK5Coords{e}(ra::T, dec::T) where {e, T <: Real} = FK5Coords{e, float(T)}(ra, dec)
 FK5Coords{e}(ra::Real, dec::Real) where {e} = FK5Coords{e}(promote(ra, dec)...)
@@ -118,7 +118,7 @@ This coordinate system is geocentric with the ecliptic plane as the xy-plane wit
 struct EclipticCoords{e, T <: Real} <: AbstractSkyCoords
     lon::T
     lat::T
-    EclipticCoords{e, T}(lon, lat) where {e, T <: Real} = new(mod2pi(lon), lat)
+    EclipticCoords{e, T}(lon::Real, lat::Real) where {e, T <: Real} = new(mod2pi(lon), lat)
 end
 EclipticCoords{e}(lon::T, lat::T) where {e, T <: Real} = EclipticCoords{e, float(T)}(lon, lat)
 EclipticCoords{e}(lon::Real, lat::Real) where {e} = EclipticCoords{e}(promote(lon, lat)...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -196,6 +196,7 @@ end
 VERSION > v"1.9-DEV" && @testset "Unitful" begin
     @test ICRSCoords(1u"rad", 0.5) === ICRSCoords(1, 0.5)
     @test GalCoords(1u"rad", 0.5u"rad") === GalCoords(1, 0.5)
+    @test SuperGalCoords(1u"rad", 0.5u"rad") === SuperGalCoords(1, 0.5)
     @test FK5Coords{2000}(1u"°", 0.5) === FK5Coords{2000}(deg2rad(1), 0.5)
     @test EclipticCoords{2000}(1u"°", 0.5u"°") === EclipticCoords{2000}(deg2rad(1), deg2rad(0.5))
 
@@ -213,12 +214,21 @@ VERSION > v"1.9-DEV" && @testset "Unitful" begin
     @test offset(ICRSCoords(1, 0.5), 0.1u"rad", 2u"rad") === offset(ICRSCoords(1, 0.5), 0.1, 2)
     @test offset(ICRSCoords(1, 0.5), 0.1, 100u"°") === offset(ICRSCoords(1, 0.5), 0.1, deg2rad(100))
     @test offset(ICRSCoords(1, 0.5), 0.1u"°", 100u"°") === offset(ICRSCoords(1, 0.5), deg2rad(0.1), deg2rad(100))
+
+    # Element-type-parameterized construction with quantities; these calls used
+    # to be ambiguous against the untyped inner constructors
+    @test ICRSCoords{Float64}(1u"rad", 0.5) === ICRSCoords(1, 0.5)
+    @test GalCoords{Float32}(1u"rad", 0.5u"rad") === GalCoords{Float32}(1, 0.5)
+    @test SuperGalCoords{Float64}(1u"rad", 0.5) === SuperGalCoords(1, 0.5)
+    @test FK5Coords{2000, Float64}(1u"°", 0.5) === FK5Coords{2000}(deg2rad(1), 0.5)
+    @test EclipticCoords{2000, Float64}(1u"°", 0.5u"°") === EclipticCoords{2000}(deg2rad(1), deg2rad(0.5))
 end
 
 VERSION > v"1.9-DEV" && @testset "DynamicQuantities" begin
     # Construction from quantities strips to plain radians (=== holds for the underlying Float64 fields).
     @test ICRSCoords(1us"rad", 0.5) === ICRSCoords(1, 0.5)
     @test GalCoords(1us"rad", 0.5us"rad") === GalCoords(1, 0.5)
+    @test SuperGalCoords(1us"rad", 0.5us"rad") === SuperGalCoords(1, 0.5)
     @test FK5Coords{2000}(1us"deg", 0.5) === FK5Coords{2000}(deg2rad(1), 0.5)
     @test EclipticCoords{2000}(1us"deg", 0.5us"deg") === EclipticCoords{2000}(deg2rad(1), deg2rad(0.5))
 
@@ -239,6 +249,25 @@ VERSION > v"1.9-DEV" && @testset "DynamicQuantities" begin
     @test offset(ICRSCoords(1, 0.5), 0.1us"rad", 2us"rad") === offset(ICRSCoords(1, 0.5), 0.1, 2)
     @test offset(ICRSCoords(1, 0.5), 0.1, 100us"deg") === offset(ICRSCoords(1, 0.5), 0.1, deg2rad(100))
     @test offset(ICRSCoords(1, 0.5), 0.1us"deg", 100us"deg") === offset(ICRSCoords(1, 0.5), deg2rad(0.1), deg2rad(100))
+
+    # Element-type-parameterized construction with quantities; these calls used
+    # to be ambiguous against the untyped inner constructors
+    @test ICRSCoords{Float64}(1us"rad", 0.5) === ICRSCoords(1, 0.5)
+    @test GalCoords{Float32}(1us"rad", 0.5us"rad") === GalCoords{Float32}(1, 0.5)
+    @test SuperGalCoords{Float64}(1us"rad", 0.5) === SuperGalCoords(1, 0.5)
+    @test FK5Coords{2000, Float64}(1us"deg", 0.5) === FK5Coords{2000}(deg2rad(1), 0.5)
+    @test EclipticCoords{2000, Float64}(1us"deg", 0.5us"deg") === EclipticCoords{2000}(deg2rad(1), deg2rad(0.5))
+end
+
+# Constructor methods across base and the units extensions are kept mutually
+# disjoint or covered; a regression here means a new method pair needs the same
+# treatment (see the typed slots in ext/UnitfulExt.jl and ext/DynamicQuantitiesExt.jl)
+VERSION > v"1.9-DEV" && @testset "method ambiguities" begin
+    exts = [
+        Base.get_extension(SkyCoords, ext) for ext in
+            (:AccessorsExt, :DynamicQuantitiesExt, :MakieExt, :NearestNeighborsExt, :UnitfulExt)
+    ]
+    @test isempty(detect_ambiguities(SkyCoords, filter(!isnothing, exts)...))
 end
 
 @testset "equality" begin


### PR DESCRIPTION
Resolve method ambiguities caught by Aqua. Will eventually roll this into the test suite as part of #108